### PR TITLE
Do not ignore singals

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -27,9 +27,6 @@ void init_menu(WINS *windows)
     int x;
     WINDOW *win;
 
-    for (x = 1; x < 24; x++)				/* blocks all signals */
-	signal(x, SIG_IGN);				/* ignores the sigs   */
-
     /*signal(SIGCHLD,  SIG_DFL);                                              */
     signal(SIGSEGV,  catchSegfault);			/* catch segfault sig */
     /* the following is still under development, please report any bugs found */


### PR DESCRIPTION
This fixes multiple issues:
- hexcurse was running 100% CPU when the terminal window got closed,
  and the HUP signal was not handled, see
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=545711;
- hexcurse was not exiting for SIGTERM;
- it was not possible to put hexcurse into the background with SIGTSTP.
