### PR TITLE
Fix manpage

### DIFF
--- a/man/hexcurse.1
+++ b/man/hexcurse.1
@@ -101,15 +101,12 @@ The authors of
 .B hexcurse
 are:
 .LP
-.SP 1n
 .RS
 James Stephenson - https://plus.google.com/u/0/103174459258175070784/about
 .RE
-.SP 1n
 .RS
 Lonny Gomes - hexcurse dot lonnygomes dot com
 .RE
-.SP 1n
 .LP
 The current version of this software is always availabe at
 .LP


### PR DESCRIPTION
The manpage was issuing warnings, see for yourself with:
  man --warnings -l man/hexcurse.1 >/dev/null

The removal of the .SP lines doesn't change the formatting, it seems.
