### PR TITLE
Fixes #13, checks if file argument is null to avoid segfault

### DIFF
--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -216,7 +216,7 @@ off_t parseArgs(int argc, char *argv[])
         fpINfilename = strdup(argv[0]);
     }
 
-    if (strcmp(fpINfilename, ""))
+    if (fpINfilename && strcmp(fpINfilename, ""))
         if ((fpIN = fopen(fpINfilename, "r")) == NULL)
             exit_err("Could not open file");
 


### PR DESCRIPTION
Avoids core dump by checking if file input parameter is defined before trying to do a string comparison.