### PR TITLE
Use malloc() and free() instead of alloca()

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -30,17 +30,6 @@
 #undef opterr
 #undef optopt
 #undef optind
-#undef alloca
-
-/* The following modification was submited by Claudio Fanin.  This change *
- * enables hexcurse to be compiled with SGI's proprietary compiler        */
-#ifdef _SGIAPI
-#include <alloca.h>
-#endif
-#ifndef __alloca
-#define __alloca      alloca
-#endif
-/* end of modification */
 
 #ifdef HAVE_OPTIND
 extern char* optarg;
@@ -85,7 +74,7 @@ exchange (argv)
      char **argv;
 {
   int nonopts_size = (last_nonopt - first_nonopt) * sizeof (char *);
-  char **temp = (char **) __alloca (nonopts_size);
+  char **temp = (char **) malloc(nonopts_size);
 
   /* Interchange the two blocks of data in ARGV.  */
 
@@ -95,6 +84,7 @@ exchange (argv)
   my_bcopy ((char *) temp,
 	    (char *) &argv[first_nonopt + optind - last_nonopt],
 	    nonopts_size);
+  free(temp);
 
   /* Update records for the slots the non-options now occupy.  */
 


### PR DESCRIPTION
This allows building with the Android NDK which lacks alloca().