### PR TITLE
Simplify alloca() usage

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -30,17 +30,8 @@
 #undef opterr
 #undef optopt
 #undef optind
-#undef alloca
 
-/* The following modification was submited by Claudio Fanin.  This change *
- * enables hexcurse to be compiled with SGI's proprietary compiler        */
-#ifdef _SGIAPI
 #include <alloca.h>
-#endif
-#ifndef __alloca
-#define __alloca      alloca
-#endif
-/* end of modification */
 
 #ifdef HAVE_OPTIND
 extern char* optarg;
@@ -85,7 +76,7 @@ exchange (argv)
      char **argv;
 {
   int nonopts_size = (last_nonopt - first_nonopt) * sizeof (char *);
-  char **temp = (char **) __alloca (nonopts_size);
+  char **temp = (char **) alloca (nonopts_size);
 
   /* Interchange the two blocks of data in ARGV.  */
 


### PR DESCRIPTION
This fixes compilation with Android NDK.

This is another variant than https://github.com/LonnyGomes/hexcurse/pull/18, which instead replaced alloca with malloc and free.

This change simplifies alloca() usage, since the current existing approach does not work with Android where alloca() is a macro and no alloca() function exists, unlike e.g. in glibc.

Is there any benefit to continue with __alloca as a macro for other platforms instead of the simpler approach in this pull request (which is the way described by http://linux.die.net/man/3/alloca and other resources)? In that case the Android build could be fixed with even more ifdef:s..