### PR TITLE
Added support for resizable terminals

### DIFF
--- a/src/acceptch.c
+++ b/src/acceptch.c
@@ -44,7 +44,6 @@ int wacceptch(WINS *win, off_t len)
     off_t cl,						/* current loc in file*/
 	  gotoLoc = 0,					/* goto location      */
 	  lastLine = 0,					/* line b4 LastLine   */
-	  currentLine = 0,				/* current line value */
 	  row = 0;
 
     char *gotoLocStr,					/* convert to gotoLoc */
@@ -93,13 +92,9 @@ int wacceptch(WINS *win, off_t len)
 
 	if (SIZE_CH)					/* if win size changed*/
 	{
-	    cl=row=col  = 0;
-	    eol         = (BASE * 3) - 1;
-	    editHex     = TRUE;
-	    Winds       = win->hex;
-	    /*cl = LastLoc;*/
-	    currentLine = 0;
-	    /*maxlines = maxLines(len);*/
+            eol         = (editHex) ? (BASE * 3) - 1 : BASE;
+            Winds       = (editHex) ? win->hex : win->ascii;
+            cl = LastLoc;
 	    SIZE_CH = FALSE;
 	}
 
@@ -399,7 +394,7 @@ int wacceptch(WINS *win, off_t len)
 	case CTRL_AND('b'):
 	case KEY_END:					/* goto end of file   */
 		if (cursorLoc(currentLine, col, editHex, BASE)==maxLoc(fpIN)-1)
-		    break;				/* alread at oef      */
+		    break;				/* already at eof     */
 		
 		/* if there's more than 1 screen, move to the last screenfull */
 		if ((maxlines - currentLine) >= MAXY)	/*if more than 1 scrn */


### PR DESCRIPTION
This patch contains modificatio to two source files, acceptch.c
and screen.c.

In acceptch.c, there is a if-block on a global variable SIZE_CH,
which is by default set to FALSE and only set to TRUE when
handling the terminal resize signal.  In previous versions,
this block provided states initialization but no other functions,
so resizable terminals was not supported.  This patch fix these
states, so that resize handler routine "checkScreenSize" in
screen.c can update the states correctly.

In screen.c, this patch re-calculates key variables like
"currentLine", remain the position after resizing a working
terminal.

Known bugs:
* long press up/down keys until the top/bottom, chances are that
  the underscore will still show on the 2nd/ the 2nd-last line.
* After multiple times of terminal resizing, the first input key catched by
  wgetch() in acceptch.c will somehow be transformed into a
  sequence of code, which will be interpreted as some ASCII
  sequence, and cause undesirable modifications.
  This is confirmed using gnome-terminal and lxterminal in Linux.

I have try my best to keep the coding style consistent, but I think I 
will fire a corresponding issue recently, since the sources are so free-style.  