### PR TITLE
fix compilation with GCC-7

### DIFF
--- a/src/acceptch.c
+++ b/src/acceptch.c
@@ -297,6 +297,7 @@ int wacceptch(WINS *win, off_t len)
 		}
 		else
 		    currentLine -= (2*MAXY);
+                /* fall through */
 
 	case CTRL_AND('d'):
 	case KEY_PGDN:					/* if KEY_PGDN...     */

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -235,10 +235,9 @@ off_t parseArgs(int argc, char *argv[])
 \********************************************************/
 int getMinimumAddressLength(off_t len)
 {
-        char buffer[1];
         int min_address_length;
         
-        min_address_length = snprintf(buffer, 1, "%jd", (intmax_t)len);
+        min_address_length = snprintf(NULL, 0, "%jd", (intmax_t)len);
         
         /* At least 8 characters wide */
         return min_address_length > 8 ? min_address_length : 8;


### PR DESCRIPTION
The new GCC 7 introduces some new error diagnostics that cause build failures for hexcurse.

This pull request fixes the two places in the code that produced errors with GCC-7.