### PR TITLE
Fix compilation with GCC 10

### DIFF
--- a/include/hex.h
+++ b/include/hex.h
@@ -126,7 +126,7 @@ extern bool color_enabled;
 #define max(a,b) ((a) >(b) ? (a) : (b))
 #endif
 
-FILE *fpIN;		        		/* global file ptr           */
+extern FILE *fpIN;	        		/* global file ptr           */
 
 /* function prototypes */
 

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -27,6 +27,8 @@
 /*#define DEBUG_LLIST*/
 /*#define DEBUG_GOTO*/
 
+FILE *fpIN;
+
 int     BASE, MAXY, resize = 0;
 int     MIN_ADDR_LENGTH;
 hexList *head;						/* linked list struct */


### PR DESCRIPTION
Fixed compilation with -fno-common, which enabled in GCC 10 by default.
See https://bugs.gentoo.org/706762.