### PR TITLE
Add -e option to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 Usage
 -----
 
-    usage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] [[-i] infile]
+    usage: hexcurse [-?|help] [-a] [-e] [-r rnum] [-o outputfile] [[-i] infile]
 
         -a          Output addresses in decimal format initially
         -e          Output characters in EBCDIC format rather than ASCII

--- a/man/hexcurse.1
+++ b/man/hexcurse.1
@@ -10,6 +10,8 @@ hexcurse \- an ncurses-based hex editor
 ] [
 .B \-a
 ] [
+.B \-e
+] [
 .B \-r
 .I rnum
 ] [
@@ -30,6 +32,9 @@ Prints out the command usage info
 .TP 15
 .B -a
 Specifies the addresses to be output in decimal format initially.
+.TP 15
+.B -e
+Specifies the characters to be output in EBCDIC format rather than ASCII.
 .TP 15
 .BI \-r \ rnum
 Specifies the number of characters per line that the hexeditor should output.  If

--- a/src/file.c
+++ b/src/file.c
@@ -99,7 +99,7 @@ void print_usage()
     char *ver = HVERSION; 
 
     printf("hexcurse, version %s by James Stephenson and Lonny Gomes\n",ver);
-    printf("\nusage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] "); 
+    printf("\nusage: hexcurse [-?|help] [-a] [-e] [-r rnum] [-o outputfile] ");
     printf("[[-i] infile]\n\n");
     printf("    -a\t\tOutput addresses in decimal format initially\n");
     printf("    -e\t\tOutput characters in EBCDIC format rather than ASCII\n"); 


### PR DESCRIPTION
Added -e option descriptions that were missing in manpage and usage lines in README and help.