### PR TITLE
Fix and cleanup option parser

### DIFF
--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -186,13 +186,13 @@ off_t parseArgs(int argc, char *argv[])
             case 'a':	printHex = FALSE;		/* decimal addresses  */
                         break;
 							/* infile             */
-	    case 'i':	free(fpINfilename);
-			fpINfilename = strdup(optarg);
-			break;
+            case 'i':	free(fpINfilename);
+                        fpINfilename = strdup(optarg);
+                        break;
 							/* outfile            */
-	    case 'o':   free(fpOUTfilename);
-			fpOUTfilename = strdup(optarg);
-			break;
+            case 'o':   free(fpOUTfilename);
+                        fpOUTfilename = strdup(optarg);
+                        break;
 
             case 'r':   resize = atoi(optarg);		/* don't resize screen*/
                         break;
@@ -201,11 +201,11 @@ off_t parseArgs(int argc, char *argv[])
                         break;
 							/* help/invalid args  */
 							/* help/invalid args  */
-	    case '?':	print_usage();			/* output help        */
+            case '?':	print_usage();			/* output help        */
                         if ((optopt == 'h') || (optopt == '?'))
-			    exit(0);			/* exit               */
-			else				/* illegal option     */
-			    exit(-1);
+                           exit(0);			/* exit               */
+            else				/* illegal option     */
+                        exit(-1);
         }
     }
     argc -= optind;

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -179,7 +179,7 @@ off_t parseArgs(int argc, char *argv[])
     int val;						/* counters, etc.     */
 
 							/* get args           */
-    while ((val = hgetopt(argc, argv, "a:i:o:r:e")) != -1) 
+    while ((val = hgetopt(argc, argv, "ai:o:r:e")) != -1)
     {
 	switch (val)					/* test args          */
         {

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -204,8 +204,8 @@ off_t parseArgs(int argc, char *argv[])
             case '?':	print_usage();			/* output help        */
                         if ((optopt == 'h') || (optopt == '?'))
                            exit(0);			/* exit               */
-            else				/* illegal option     */
-                        exit(-1);
+                        else				/* illegal option     */
+                           exit(-1);
         }
     }
     argc -= optind;


### PR DESCRIPTION
Fix the parsing of -a option that was wronly expecting an argument.
Also cleanup a bit the getopt code block.