### PR TITLE
Fix colors for some terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 Usage
 -----
 
-    usage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] [[-i] infile]
+    usage: hexcurse [-?|help] [-a] [-e] [-r rnum] [-o outputfile] [[-i] infile]
 
         -a          Output addresses in decimal format initially
         -e          Output characters in EBCDIC format rather than ASCII

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 Usage
 -----
 
-    usage: hexcurse [-?|help] [-a] [-e] [-r rnum] [-o outputfile] [[-i] infile]
+    usage: hexcurse [-?|help] [-a] [-e] [-t] [-r rnum] [-o outputfile] [[-i] infile]
 
         -a          Output addresses in decimal format initially
         -e          Output characters in EBCDIC format rather than ASCII

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Usage
 
         -a          Output addresses in decimal format initially
         -e          Output characters in EBCDIC format rather than ASCII
+        -t          Keep colors defined by terminal
         -r rnum     Resize the display to "rnum" bytes wide
         -o outfile  Write output to outfile by default
         -? | -help  Display usage and version of hexcurse program

--- a/include/hex.h
+++ b/include/hex.h
@@ -100,6 +100,7 @@ extern int  SIZE_CH;
 extern bool USE_EBCDIC;
 extern char EBCDIC[256];
 extern bool color_enabled;
+extern bool TERM_COLORS;
 
 /* macros */
 /*#define currentLoc(line, col) ((line) * BASE +((col)/3)) */

--- a/man/hexcurse.1
+++ b/man/hexcurse.1
@@ -10,6 +10,8 @@ hexcurse \- an ncurses-based hex editor
 ] [
 .B \-a
 ] [
+.B \-e
+] [
 .B \-r
 .I rnum
 ] [
@@ -30,6 +32,9 @@ Prints out the command usage info
 .TP 15
 .B -a
 Specifies the addresses to be output in decimal format initially.
+.TP 15
+.B -e
+Specifies the characters to be output in EBCDIC format rather than ASCII.
 .TP 15
 .BI \-r \ rnum
 Specifies the number of characters per line that the hexeditor should output.  If

--- a/man/hexcurse.1
+++ b/man/hexcurse.1
@@ -12,6 +12,8 @@ hexcurse \- an ncurses-based hex editor
 ] [
 .B \-e
 ] [
+.B \-t
+] [
 .B \-r
 .I rnum
 ] [
@@ -35,6 +37,9 @@ Specifies the addresses to be output in decimal format initially.
 .TP 15
 .B -e
 Specifies the characters to be output in EBCDIC format rather than ASCII.
+.TP 15
+.B -t
+Specifies the colors set by the terminal should be kept (all background and normal foreground). Set this if you see ugly colors or don't see some colors at all.
 .TP 15
 .BI \-r \ rnum
 Specifies the number of characters per line that the hexeditor should output.  If

--- a/src/color.c
+++ b/src/color.c
@@ -16,15 +16,29 @@ void init_colors(void)
     if(color_enabled)
     {
         start_color();
-        init_pair(1, COLOR_BLACK,   COLOR_BLACK);
-        init_pair(2, COLOR_RED,     COLOR_BLACK);
-        init_pair(3, COLOR_GREEN,   COLOR_BLACK);
-        init_pair(4, COLOR_YELLOW,  COLOR_BLACK);
-        init_pair(5, COLOR_BLUE,    COLOR_BLACK);
-        init_pair(6, COLOR_MAGENTA, COLOR_BLACK);
-        init_pair(7, COLOR_CYAN,    COLOR_BLACK);
-        init_pair(8, COLOR_WHITE,   COLOR_BLACK);
-
+        if (TERM_COLORS)
+        {
+            use_default_colors();
+            init_pair(1, COLOR_BLACK,   -1);
+            init_pair(2, COLOR_RED,     -1);
+            init_pair(3, COLOR_GREEN,   -1);
+            init_pair(4, COLOR_YELLOW,  -1);
+            init_pair(5, COLOR_BLUE,    -1);
+            init_pair(6, COLOR_MAGENTA, -1);
+            init_pair(7, COLOR_CYAN,    -1);
+            init_pair(8, COLOR_WHITE,   -1);
+        }
+        else
+        {
+            init_pair(1, COLOR_BLACK,   COLOR_BLACK);
+            init_pair(2, COLOR_RED,     COLOR_BLACK);
+            init_pair(3, COLOR_GREEN,   COLOR_BLACK);
+            init_pair(4, COLOR_YELLOW,  COLOR_BLACK);
+            init_pair(5, COLOR_BLUE,    COLOR_BLACK);
+            init_pair(6, COLOR_MAGENTA, COLOR_BLACK);
+            init_pair(7, COLOR_CYAN,    COLOR_BLACK);
+            init_pair(8, COLOR_WHITE,   COLOR_BLACK);
+        }
     }
 }
 

--- a/src/file.c
+++ b/src/file.c
@@ -99,7 +99,7 @@ void print_usage()
     char *ver = HVERSION; 
 
     printf("hexcurse, version %s by James Stephenson and Lonny Gomes\n",ver);
-    printf("\nusage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] "); 
+    printf("\nusage: hexcurse [-?|help] [-a] [-e] [-r rnum] [-o outputfile] ");
     printf("[[-i] infile]\n\n");
     printf("    -a\t\tOutput addresses in decimal format initially\n");
     printf("    -e\t\tOutput characters in EBCDIC format rather than ASCII\n"); 

--- a/src/file.c
+++ b/src/file.c
@@ -103,6 +103,7 @@ void print_usage()
     printf("[[-i] infile]\n\n");
     printf("    -a\t\tOutput addresses in decimal format initially\n");
     printf("    -e\t\tOutput characters in EBCDIC format rather than ASCII\n"); 
+    printf("    -t\tKeep colors defined by terminal\n");
     printf("    -r rnum\tResize the display to \"rnum\" bytes wide\n");
     printf("    -o outfile\tWrite output to outfile by default\n"); 
     printf("    -? | -help\tDisplay usage and version of hexcurse program\n");

--- a/src/file.c
+++ b/src/file.c
@@ -99,7 +99,7 @@ void print_usage()
     char *ver = HVERSION; 
 
     printf("hexcurse, version %s by James Stephenson and Lonny Gomes\n",ver);
-    printf("\nusage: hexcurse [-?|help] [-a] [-e] [-r rnum] [-o outputfile] ");
+    printf("\nusage: hexcurse [-?|help] [-a] [-e] [-t] [-r rnum] [-o outputfile] ");
     printf("[[-i] infile]\n\n");
     printf("    -a\t\tOutput addresses in decimal format initially\n");
     printf("    -e\t\tOutput characters in EBCDIC format rather than ASCII\n"); 

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -186,13 +186,13 @@ off_t parseArgs(int argc, char *argv[])
             case 'a':	printHex = FALSE;		/* decimal addresses  */
                         break;
 							/* infile             */
-	    case 'i':	free(fpINfilename);
-			fpINfilename = strdup(optarg);
-			break;
+            case 'i':	free(fpINfilename);
+                        fpINfilename = strdup(optarg);
+                        break;
 							/* outfile            */
-	    case 'o':   free(fpOUTfilename);
-			fpOUTfilename = strdup(optarg);
-			break;
+            case 'o':   free(fpOUTfilename);
+                        fpOUTfilename = strdup(optarg);
+                        break;
 
             case 'r':   resize = atoi(optarg);		/* don't resize screen*/
                         break;
@@ -201,11 +201,11 @@ off_t parseArgs(int argc, char *argv[])
                         break;
 							/* help/invalid args  */
 							/* help/invalid args  */
-	    case '?':	print_usage();			/* output help        */
+            case '?':	print_usage();			/* output help        */
                         if ((optopt == 'h') || (optopt == '?'))
-			    exit(0);			/* exit               */
-			else				/* illegal option     */
-			    exit(-1);
+                           exit(0);			/* exit               */
+            else				/* illegal option     */
+                        exit(-1);
         }
     }
     argc -= optind;

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -179,7 +179,7 @@ off_t parseArgs(int argc, char *argv[])
     int val;						/* counters, etc.     */
 
 							/* get args           */
-    while ((val = hgetopt(argc, argv, "a:i:o:r:e")) != -1) 
+    while ((val = hgetopt(argc, argv, "ai:o:r:e")) != -1)
     {
 	switch (val)					/* test args          */
         {

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -36,6 +36,7 @@ char    EBCDIC[256],
         *fpOUTfilename = NULL;
 bool 	printHex;					/* address format     */
 bool    USE_EBCDIC;
+bool    TERM_COLORS;
 bool    IN_HELP;					/* if help displayed  */
 int     hex_win_width,
         ascii_win_width,
@@ -75,6 +76,7 @@ int main(int argc, char *argv[])			/* main program       */
     fpOUTfilename = NULL;			/* out file name ptrs */
     printHex = TRUE;							/* address format     */
     USE_EBCDIC = FALSE;							/*use ascii by default*/
+    TERM_COLORS = FALSE;                     /*don't use term defined colors by default */
 
 							/* get cmd line args  */
     len = parseArgs(argc, argv);
@@ -179,7 +181,7 @@ off_t parseArgs(int argc, char *argv[])
     int val;						/* counters, etc.     */
 
 							/* get args           */
-    while ((val = hgetopt(argc, argv, "ai:o:r:e")) != -1)
+    while ((val = hgetopt(argc, argv, "ai:o:r:et")) != -1)
     {
 	switch (val)					/* test args          */
         {
@@ -199,6 +201,9 @@ off_t parseArgs(int argc, char *argv[])
 
             case 'e':   USE_EBCDIC=TRUE;		/*use instead of ascii*/
                         break;
+
+            case 't':   TERM_COLORS=TRUE;       /* keep term defined colors */
+                        break;                  /* if defined and not set may look bad */
 							/* help/invalid args  */
 							/* help/invalid args  */
             case '?':	print_usage();			/* output help        */


### PR DESCRIPTION
In some terminals, e.g. urxvt if the background color is set (e.g.  purple) this is the result:

![hexcurse](https://user-images.githubusercontent.com/19615588/85176831-a4419a00-b272-11ea-8352-560708f28732.png)

This is because hexcurse forces the background color to black. So the -t option keeps the background color of the terminal, expected result:

![hexcurse-t](https://user-images.githubusercontent.com/19615588/85176933-e074fa80-b272-11ea-9ba6-d718ef6382c8.png)

Note: this PR include commits from PR #29 and PR #30 to avoid merge conflicts.