### PR TITLE
Add color levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,19 @@ Installation
 Usage
 -----
 
-    usage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] [[-i] infile]
+    usage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] [[-i] infile] [-c colorlevel]
 
-        -a          Output addresses in decimal format initially
-        -e          Output characters in EBCDIC format rather than ASCII
-        -r rnum     Resize the display to "rnum" bytes wide
-        -o outfile  Write output to outfile by default
-        -? | -help  Display usage and version of hexcurse program
-        [-i] infile Read from data from infile (-i required if not last argument)
+        -a            Output addresses in decimal format initially
+        -e            Output characters in EBCDIC format rather than ASCII
+        -r rnum       Resize the display to "rnum" bytes wide
+        -o outfile    Write output to outfile by default
+        -? | -help    Display usage and version of hexcurse program
+        [-i] infile   Read from data from infile (-i required if not last argument)
+        -c colorlevel Set the color level:
+                        0: no colors
+                        1: only color for addresses
+                        2: 1 + color for 00 (default if terminal supports color)
+                        3: multicolor by FrankSansC
 
 #### Keyboard shortcuts
 

--- a/include/hex.h
+++ b/include/hex.h
@@ -100,6 +100,7 @@ extern int  SIZE_CH;
 extern bool USE_EBCDIC;
 extern char EBCDIC[256];
 extern bool color_enabled;
+extern int  color_level;
 
 /* macros */
 /*#define currentLoc(line, col) ((line) * BASE +((col)/3)) */

--- a/man/hexcurse.1
+++ b/man/hexcurse.1
@@ -19,6 +19,9 @@ hexcurse \- an ncurses-based hex editor
 .BR \-i
 ]
 .I inputfile
+] [
+.BR \-c
+I. colorlevel
 ]
 .SH DESCRIPTION
 .B hexcurse
@@ -49,6 +52,21 @@ Specifies the input file to be read in.
 is not needed if
 .I inputfile
 is the last argument on the line.
+.TP 15
+.BI [ \-c ] \ colorlevel
+Specifies the color level.
+.RS 18
+0: no colors
+.RE
+.RS 18
+1: only color for addresses
+.RE
+.RS 18
+2: 1 + color for 00 (default if terminal supports color)
+.RE
+.RS 18
+3: multicolor by FrankSansC
+.RE
 .SH INTERACTIVE OPTIONS
 .TP 15
 .B F1 | ctrl+?

--- a/src/acceptch.c
+++ b/src/acceptch.c
@@ -204,26 +204,42 @@ int wacceptch(WINS *win, off_t len)
 
 			wattron(win->hex, A_BOLD);
 			wattron(win->ascii, A_BOLD);
-							/* output it          */
-			wprintw(Winds, "%c", editHex ? toupper(key): key);
 
 			tmpval = val;			/* val b4 key press   */
 
 			if (editHex)			/* if in hex win...   */
 			{
-			    if (key >= 65 && key <= 70)	/* get correct val    */
-			    	key -= 7;
-			    else if (key >= 97 && key <= 102)
-			    	key -= 39;
-			    key -= 48;
-			
-			    if ((col % 3) == 0)		/* compute byte val   */
-                            val = (key * 16) + (val % 16);
-			    else if ((col % 3) == 1)
-			    	val = (val - ((val + 16) % 16) + key);
+				short int tmpkey = key;
+
+				if (tmpkey >= 65 && tmpkey <= 70)	/* get correct val    */
+					tmpkey -= 7;
+				else if (tmpkey >= 97 && tmpkey <= 102)
+					tmpkey -= 39;
+				tmpkey -= 48;
+
+				if ((col % 3) == 0)		/* compute byte val */
+				{                  		/* and update color */
+				        				/* first digit hex  */
+					val = (tmpkey * 16) + (val % 16);
+					byte_color_on((row * BASE) + col, val);
+					wprintw(Winds, "%02X", val);
+				}
+				else if ((col % 3) == 1)
+				     {					/* second digit hex */
+				     	val = (val - ((val + 16) % 16) + tmpkey);
+				     	byte_color_on((row * BASE) + col, val);
+				     	wmove(win->hex, row, col-1);
+				     	wprintw(Winds, "%02X", val);
+				     	wmove(win->hex, row, col);
+				     }
 			}
 			else				/* else...            */
-			    val = key;			/* val is key pressed */
+			{
+				val = key;			/* val is key pressed */
+				          			/* output it          */
+				byte_color_on((row * BASE) + col, val);
+				wprintw(Winds, "%c", key);
+			}
 
 			if (editHex)			/* update ascii win   */
 			{
@@ -240,6 +256,7 @@ int wacceptch(WINS *win, off_t len)
 			    wmove(win->ascii, row, col);
 			    wrefresh(win->hex);
 			}
+			byte_color_off((row * BASE) + col, val);
 
 			wattrset(win->hex, A_NORMAL);
 			wattrset(win->ascii, A_NORMAL);

--- a/src/color.c
+++ b/src/color.c
@@ -13,7 +13,7 @@ bool color_enabled;
 void init_colors(void)
 {
     color_enabled = has_colors();
-    if(color_enabled)
+    if(color_enabled && color_level>0)
     {
         start_color();
         init_pair(1, COLOR_BLACK,   COLOR_BLACK);
@@ -35,14 +35,16 @@ void init_colors(void)
 int get_byte_color(intmax_t address, char c)
 {
     UNUSED(address);
-    if (((unsigned char) c >= 0x20) && ((unsigned char) c <= 0x7E)) {
-        return COLOR_PAIR(8);
-    } else if ((unsigned char) c == 0xFF) {
-        return COLOR_PAIR(2);
-    } else if ((unsigned char) c == 0x00) {
-        return COLOR_PAIR(5);
-    }
-    return COLOR_PAIR(7);
+    if ((unsigned char) c == 0x00)
+        return ((color_level>1) ? COLOR_PAIR(5) : A_NORMAL);
+
+    if (color_level>2)
+      if (((unsigned char) c >= 0x20) && ((unsigned char) c <= 0x7E)) {
+          return COLOR_PAIR(8);
+      } else if ((unsigned char) c == 0xFF) {
+          return COLOR_PAIR(2);
+      } else return COLOR_PAIR(7);
+    else return A_NORMAL;
 }
 
 void byte_color_on(intmax_t address, char c)
@@ -70,7 +72,7 @@ void byte_color_off(intmax_t address, char c)
 int get_address_color(intmax_t address)
 {
   UNUSED(address);
-  return COLOR_PAIR(4);
+  return ((color_level>0) ? COLOR_PAIR(4) : A_NORMAL);
 }
 
 void address_color_on(intmax_t address)

--- a/src/color.c
+++ b/src/color.c
@@ -35,10 +35,14 @@ void init_colors(void)
 int get_byte_color(intmax_t address, char c)
 {
     UNUSED(address);
-    if (c == 0x00) {
+    if (((unsigned char) c >= 0x20) && ((unsigned char) c <= 0x7E)) {
+        return COLOR_PAIR(8);
+    } else if ((unsigned char) c == 0xFF) {
+        return COLOR_PAIR(2);
+    } else if ((unsigned char) c == 0x00) {
         return COLOR_PAIR(5);
     }
-    return A_NORMAL;
+    return COLOR_PAIR(7);
 }
 
 void byte_color_on(intmax_t address, char c)

--- a/src/file.c
+++ b/src/file.c
@@ -100,13 +100,18 @@ void print_usage()
 
     printf("hexcurse, version %s by James Stephenson and Lonny Gomes\n",ver);
     printf("\nusage: hexcurse [-?|help] [-a] [-r rnum] [-o outputfile] "); 
-    printf("[[-i] infile]\n\n");
-    printf("    -a\t\tOutput addresses in decimal format initially\n");
-    printf("    -e\t\tOutput characters in EBCDIC format rather than ASCII\n"); 
-    printf("    -r rnum\tResize the display to \"rnum\" bytes wide\n");
-    printf("    -o outfile\tWrite output to outfile by default\n"); 
-    printf("    -? | -help\tDisplay usage and version of hexcurse program\n");
-    printf("    [-i] infile\tRead from data from infile (-i required if not last argument)\n\n");
+    printf("[[-i] infile] [-c colorlevel]\n\n");
+    printf("    -a\t\t  Output addresses in decimal format initially\n");
+    printf("    -e\t\t  Output characters in EBCDIC format rather than ASCII\n");
+    printf("    -r rnum\t  Resize the display to \"rnum\" bytes wide\n");
+    printf("    -o outfile\t  Write output to outfile by default\n");
+    printf("    -? | -help\t  Display usage and version of hexcurse program\n");
+    printf("    [-i] infile\t  Read from data from infile (-i required if not last argument)\n");
+    printf("    -c colorlevel Set the color level\n");
+    printf("    \t\t    0: no colors\n");
+    printf("    \t\t    1: only color for addresses\n");
+    printf("    \t\t    2: 1 + color for 00 (default if terminal supports color)\n");
+    printf("    \t\t    3: multicolor by FrankSansC\n\n");
 }
 
 /*******************************************************\

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -186,13 +186,13 @@ off_t parseArgs(int argc, char *argv[])
             case 'a':	printHex = FALSE;		/* decimal addresses  */
                         break;
 							/* infile             */
-	    case 'i':	free(fpINfilename);
-			fpINfilename = strdup(optarg);
-			break;
+            case 'i':	free(fpINfilename);
+                        fpINfilename = strdup(optarg);
+                        break;
 							/* outfile            */
-	    case 'o':   free(fpOUTfilename);
-			fpOUTfilename = strdup(optarg);
-			break;
+            case 'o':   free(fpOUTfilename);
+                        fpOUTfilename = strdup(optarg);
+                        break;
 
             case 'r':   resize = atoi(optarg);		/* don't resize screen*/
                         break;
@@ -201,11 +201,11 @@ off_t parseArgs(int argc, char *argv[])
                         break;
 							/* help/invalid args  */
 							/* help/invalid args  */
-	    case '?':	print_usage();			/* output help        */
+            case '?':	print_usage();			/* output help        */
                         if ((optopt == 'h') || (optopt == '?'))
-			    exit(0);			/* exit               */
-			else				/* illegal option     */
-			    exit(-1);
+                           exit(0);			/* exit               */
+            else				/* illegal option     */
+                        exit(-1);
         }
     }
     argc -= optind;

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -40,7 +40,8 @@ bool    IN_HELP;					/* if help displayed  */
 int     hex_win_width,
         ascii_win_width,
         hex_outline_width,
-        ascii_outline_width;
+        ascii_outline_width,
+        color_level = 2;
 
 
     /* partial EBCDIC table contributed by Ted (ted@php.net) */
@@ -179,10 +180,18 @@ off_t parseArgs(int argc, char *argv[])
     int val;						/* counters, etc.     */
 
 							/* get args           */
-    while ((val = hgetopt(argc, argv, "ai:o:r:e")) != -1)
+    while ((val = hgetopt(argc, argv, "c:ai:o:r:e")) != -1)
     {
 	switch (val)					/* test args          */
         {
+            case 'c':   color_level = atoi(optarg);
+                        if (color_level<0 || color_level>3)
+                        {
+                            print_usage();
+                            exit(-1);
+                        }
+                        break;
+
             case 'a':	printHex = FALSE;		/* decimal addresses  */
                         break;
 							/* infile             */

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -179,7 +179,7 @@ off_t parseArgs(int argc, char *argv[])
     int val;						/* counters, etc.     */
 
 							/* get args           */
-    while ((val = hgetopt(argc, argv, "a:i:o:r:e")) != -1) 
+    while ((val = hgetopt(argc, argv, "ai:o:r:e")) != -1)
     {
 	switch (val)					/* test args          */
         {


### PR DESCRIPTION
Add color level option (-c) to control how to render colors for values
Color levels:
  0: no colors (monochrome)
  1: only color for addresses (yellow)
  2: 1 + blue color for 00 (default if terminal supports color)
  3: 1 + multicolor scheme by FrankSansC
    - from 0x20 to 0x7E included (printable characters) = white
    - 0x00 = blue
    - 0xFF = red
    - all other values = cyan

Note: this includes some commits from PR #30 to avoid merge conflicts