### PR TITLE
Add saved/unsaved status

### DIFF
--- a/include/hex.h
+++ b/include/hex.h
@@ -74,7 +74,6 @@ struct Stack {					/* struct to be used for stack*/
     int savedVal;
     off_t currentLoc;
     struct Stack *prev;
-    struct LinkedList *llist;
 };
 
 /* typedefs */
@@ -100,6 +99,7 @@ extern int  SIZE_CH;
 extern bool USE_EBCDIC;
 extern char EBCDIC[256];
 extern bool color_enabled;
+extern bool saved;
 
 /* macros */
 /*#define currentLoc(line, col) ((line) * BASE +((col)/3)) */
@@ -108,7 +108,6 @@ extern bool color_enabled;
 						/* cursor location in the file*/
 #define cursorLoc(line,col,editHex,b) (((line)*(b)) + ((col)/((editHex)?3:1)))
 #define llalloc() (struct LinkedList *) calloc(1, sizeof(struct LinkedList))
-#define isEmptyStack(stack) (((stack) == NULL) ? TRUE : FALSE)
 
 #define UNUSED(x) (void)(x)
 
@@ -119,6 +118,7 @@ extern bool color_enabled;
 #define MIN_COLS        70                      /* screen has to be 70< cols  */
 #define MIN_LINES       7     /* 8 - 1 */       /* the slk crap minuses 1 line*/
 #define KEY_TAB 		9			/* value for the tab key      */
+#define SAVEPOINT      -1
 
 #define AlphabetSize (UCHAR_MAX +1)		/* for portability            */
 
@@ -138,6 +138,7 @@ char *inputLine(WINDOW *win, int line, int col);
 /* file.c */
 void outline(FILE *fp, off_t linenum);
 off_t maxLoc(FILE *fp);
+void set_saved(bool sav, WINDOW *win);
 void print_usage();
 off_t maxLines(off_t len);
 int openfile(WINS *win);
@@ -181,8 +182,7 @@ void popupWin(char *msg, int time);
 short int questionWin(char *msg);
 
 /* stack.c */
-void createStack(hexStack *stack);
-void pushStack(hexStack **stack, hexStack *tmpStack);
+void pushStack(hexStack **stack, off_t cl, int val);
 void popStack(hexStack **stack);
 void smashDaStack(hexStack **stack);
 

--- a/src/file.c
+++ b/src/file.c
@@ -90,6 +90,31 @@ off_t maxLoc(FILE *fp)
     return(ftello(fp));				/* return val at EOF  */
 }
 
+/*******************************************************\
+ * Description: enters o exits from modified mode:     *
+ *      set or reset saved, and write or restore       *
+ *      mode indicator (*) at top of hex window        *
+\*******************************************************/
+void set_saved(bool sav, WINDOW *win)
+{
+    int y, x;
+
+    getyx(win, y, x);
+    if ( (saved = sav) )  /* set, not compare */
+    {
+        mvwaddch(windows->hex_outline, 0, 11, ACS_HLINE);
+        mvwaddch(windows->hex_outline, 0, 12, ACS_HLINE);
+        mvwaddch(windows->hex_outline, 0, 13, ACS_HLINE);
+        wnoutrefresh(windows->hex_outline);
+    }
+    else
+    {
+        mvwprintw(windows->hex_outline, 0, 11, " * ");
+        wnoutrefresh(windows->hex_outline);
+    }
+    wmove(win, y, x);
+}
+
 /******************************************************\
  * Description: prints out the command line help info *
  *		this function does not return anything*

--- a/src/file.c
+++ b/src/file.c
@@ -102,14 +102,14 @@ void set_saved(bool sav, WINDOW *win)
     getyx(win, y, x);
     if ( (saved = sav) )  /* set, not compare */
     {
-        mvwaddch(windows->hex_outline, 0, 11, ACS_HLINE);
-        mvwaddch(windows->hex_outline, 0, 12, ACS_HLINE);
-        mvwaddch(windows->hex_outline, 0, 13, ACS_HLINE);
+        mvwaddch(windows->hex_outline, 0, MIN_ADDR_LENGTH+3, ACS_HLINE);
+        mvwaddch(windows->hex_outline, 0, MIN_ADDR_LENGTH+4, ACS_HLINE);
+        mvwaddch(windows->hex_outline, 0, MIN_ADDR_LENGTH+5, ACS_HLINE);
         wnoutrefresh(windows->hex_outline);
     }
     else
     {
-        mvwprintw(windows->hex_outline, 0, 11, " * ");
+        mvwprintw(windows->hex_outline, 0, MIN_ADDR_LENGTH+3, " * ");
         wnoutrefresh(windows->hex_outline);
     }
     wmove(win, y, x);

--- a/src/hexcurse.c
+++ b/src/hexcurse.c
@@ -37,6 +37,7 @@ char    EBCDIC[256],
 bool 	printHex;					/* address format     */
 bool    USE_EBCDIC;
 bool    IN_HELP;					/* if help displayed  */
+bool    saved = TRUE;
 int     hex_win_width,
         ascii_win_width,
         hex_outline_width,

--- a/src/stack.c
+++ b/src/stack.c
@@ -19,42 +19,28 @@
 #include "hex.h"
 
 /******************************************************\
- * Description: the just sets the stack pointer to    *
- * 		NULL; it really has no business being *
- *		function anyways		      *
-\******************************************************/
-void createStack(hexStack *stack)
-{
-    /* calloc() is used because it NULLS out all returned memory */
-    /* stack = (hexStack *) calloc(1, sizeof(hexStack));
-    stack->llist = NULL;
-    stack->prev = NULL;
-    */
-    stack = NULL;
-    stack->llist = NULL;
-    stack->prev = NULL;
-}
-
-/******************************************************\
  * Description: this pushes a structure of type       *
  *		hexStack to the stack.  NULL being the*
  *		initial state of the stack            *
 \******************************************************/
-void pushStack(hexStack **stack, hexStack *tmpStack)
+void pushStack(hexStack **stack, off_t cl, int val)
 {
-    hexStack *oldStack;
+    hexStack *oldStack, *newStack;
     oldStack = *stack;
 
+    /* calloc() is used because it NULLS out all returned memory  */
+    newStack = (hexStack *) calloc(1, sizeof(hexStack));
+    newStack->currentLoc = cl;
+    newStack->savedVal = val;
+
     if (oldStack == NULL)				/* begining of stack  */
-        *stack = tmpStack;
+        *stack = newStack;
     else 
     {
-        tmpStack->prev = oldStack;
-        *stack = tmpStack;
-
+        newStack->prev = oldStack;
+        *stack = newStack;
     }
 }
-
 
 /******************************************************\
  * Description: This function pops a structure off of *


### PR DESCRIPTION
Until now the question "Do you want to save changes?" at quit was triggered if the stack (for undo) was not empty, this was wrong because you could save at any point and this would not empty the stack, and you could undo changes previous to the save what is a desirable function.

Now we keep a saved/unsaved state that is set when saving (pushing a special value in the stack) that is carefully checked when using the undo function.

The unsaved state is indicated by "*" at top left, at right of current address, emacs style.
