### PR TITLE
src/screen.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -451,7 +451,7 @@ void popupWin(char *msg, int time)
 
     keypad(tmpwin, TRUE);
 
-    mvwprintw(tmpwin,2,3, msg);				/* output mesg        */
+    mvwprintw(tmpwin,2,3, "%s", msg);			/* output mesg        */
     wmove(tmpwin,2,len+4);
     wrefresh(tmpwin);
 
@@ -492,7 +492,7 @@ short int questionWin(char *msg)
 
     tmpwin = drawbox(y, x, 5, len + 6);			/* create window      */
 
-    mvwprintw(tmpwin,2,3, msg);
+    mvwprintw(tmpwin,2,3, "%s", msg);
     wmove(tmpwin,2,len+4);
     wrefresh(tmpwin);
 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    screen.c:495:5: error: format not a string literal and no format arguments [-Werror=format-security]
      495 |     mvwprintw(tmpwin,2,3, msg);
          |     ^~~~~~~~~

Let's wrap all the missing places with "%s" format.